### PR TITLE
Fallback to original unicode in RFC1459toIRCLower

### DIFF
--- a/js/irc/irclib.js
+++ b/js/irc/irclib.js
@@ -36,9 +36,9 @@ qwebirc.irc.IRCLowerTable = [
 qwebirc.irc.RFC1459toIRCLower = function(x) {
   var p = [];
   for(var i=0;i<x.length;i++) {
-    var l = x.charCodeAt(i);
+    var l = qwebirc.irc.IRCLowerTable[x.charCodeAt(i)];
 
-    p.push(qwebirc.irc.IRCLowerTable[l]);
+    p.push(l || x.charAt(i));
   }
     
   return p.join("");


### PR DESCRIPTION
Instead of removing unicode characters (> 0xFF) in RFC1459toIRCLower this falls back to return them.

Fixes #313, where channel tabs with names purely outside of that range were merged into a single window, because RFC1459toIRCLower returns empty strings.

The ASCII tolower function handles full unicode tolower, RFC1459 tolower still doesn't, so that is still inconsistent. I would think restricting the ASCII function to 0x00-0xFF is more reasonable than extending the RFC1459 one to do it in full unicode range, because most IRCds don't do that. And if they do, that probably warrants a separate CASEMAPPING value other than rfc1459/ascii.