### PR TITLE
dns: support IPv6 and nontrivial answers (CNAME, DNAME, etc.)

### DIFF
--- a/qwebirc/dns.py
+++ b/qwebirc/dns.py
@@ -17,10 +17,12 @@ def lookupPTR(ip, *args, **kwargs):
   return client.lookupPointer(ptr, **kwargs).addCallback(callback)
 
 def expandIPv6(ip):
-  expand_start, expand_end = ["".join(["{:0>4}".format(group)
+  expand_sections = ["".join(["{:0>4}".format(group)
       for group in section.split(":")])
         for section in ip.split("::")]
-  return expand_start + (32-len(expand_start)-len(expand_end))*"0" + expand_end
+  if len(expand_sections) == 1:
+      return expand_sections[0]
+  return expand_sections[0] + (32-len(expand_start)-len(expand_end))*"0" + expand_sections[1:]
 
 def lookupPTRv6(ip, *args, **kwargs):
   def callback(result):

--- a/qwebirc/dns.py
+++ b/qwebirc/dns.py
@@ -16,6 +16,23 @@ def lookupPTR(ip, *args, **kwargs):
   ptr = ".".join(ip.split(".")[::-1]) + ".in-addr.arpa."
   return client.lookupPointer(ptr, **kwargs).addCallback(callback)
 
+def expandIPv6(ip):
+  expand_start, expand_end = ["".join(["{:0>4}".format(group)
+      for group in section.split(":")])
+        for section in ip.split("::")]
+  return expand_start + (32-len(expand_start)-len(expand_end))*"0" + expand_end
+
+def lookupPTRv6(ip, *args, **kwargs):
+  def callback(result):
+    answer, auth, add = result
+
+    if len(answer) == 0:
+      raise LookupException, "No ANSWERS in PTR response for %s." % repr(ip)
+    return str(answer[0].payload.name)
+
+  ptr = ".".join(reversed(expandIPv6(ip))) + ".ip6.arpa."
+  return client.lookupPointer(ptr, **kwargs).addCallback(callback)
+
 def lookupAs(hostname, *args, **kwargs):
   def callback(result):
     answer, auth, add = result
@@ -24,6 +41,15 @@ def lookupAs(hostname, *args, **kwargs):
     return [x.payload.dottedQuad() for x in answer]
 
   return client.lookupAddress(hostname, *args, **kwargs).addCallback(callback)
+
+def lookupAAAAs(hostname, *args, **kwargs):
+  def callback(result):
+    answer, auth, add = result
+    if len(answer) == 0:
+      raise LookupException, "No ANSWERS in AAAA response for %s." % repr(hostname)
+    return [expandIPv6(x.payload._address) for x in answer]
+
+  return client.lookupIPV6Address(hostname, *args, **kwargs).addCallback(callback)
 
 def lookupAndVerifyPTR(ip, *args, **kwargs):
   d = defer.Deferred()
@@ -36,7 +62,18 @@ def lookupAndVerifyPTR(ip, *args, **kwargs):
         raise VerificationException("IP mismatch: %s != %s%s" % (repr(ip), repr(ptr), repr(a_records)))
     lookupAs(ptr, *args, **kwargs).addCallback(gotAResult).addErrback(d.errback)
 
-  lookupPTR(ip, *args, **kwargs).addCallback(gotPTRResult).addErrback(d.errback)
+  def gotPTRv6Result(ptr):
+    def gotAAAAResult(aaaa_records):
+      if expandIPv6(ip) in aaaa_records:
+        d.callback(ptr)
+      else:
+        raise VerificationException("IPv6 mismatch: %s != %s%s" % (repr(ip), repr(ptr), repr(aaaa_records)))
+    lookupAAAAs(ptr, *args, **kwargs).addCallback(gotAAAAResult).addErrback(d.errback)
+
+  if ":" in ip:
+    lookupPTRv6(ip, *args, **kwargs).addCallback(gotPTRv6Result).addErrback(d.errback)
+  else:
+    lookupPTR(ip, *args, **kwargs).addCallback(gotPTRResult).addErrback(d.errback)
   return d
 
 if __name__ == "__main__":
@@ -50,7 +87,7 @@ if __name__ == "__main__":
     x.printTraceback()
     reactor.stop()
 
-  d = lookupAndVerifyPTR(sys.argv[1], timeout=[.001])
+  d = lookupAndVerifyPTR(sys.argv[1], timeout=[3])
   d.addCallbacks(callback, errback)
 
   reactor.run()

--- a/qwebirc/dns.py
+++ b/qwebirc/dns.py
@@ -1,4 +1,4 @@
-from twisted.names import client
+from twisted.names import client, dns
 from twisted.internet import reactor, defer
 
 class LookupException(Exception): pass
@@ -8,7 +8,7 @@ TimeoutException = defer.TimeoutError
 def lookupPTR(ip, *args, **kwargs):
   def callback(result):
     answer, auth, add = result
-
+    answer = [x for x in answer if x.type == dns.PTR]
     if len(answer) == 0:
       raise LookupException, "No ANSWERS in PTR response for %s." % repr(ip)
     return str(answer[0].payload.name)
@@ -25,7 +25,7 @@ def expandIPv6(ip):
 def lookupPTRv6(ip, *args, **kwargs):
   def callback(result):
     answer, auth, add = result
-
+    answer = [x for x in answer if x.type == dns.PTR]
     if len(answer) == 0:
       raise LookupException, "No ANSWERS in PTR response for %s." % repr(ip)
     return str(answer[0].payload.name)
@@ -36,6 +36,7 @@ def lookupPTRv6(ip, *args, **kwargs):
 def lookupAs(hostname, *args, **kwargs):
   def callback(result):
     answer, auth, add = result
+    answer = [x for x in answer if x.type == dns.A]
     if len(answer) == 0:
       raise LookupException, "No ANSWERS in A response for %s." % repr(hostname)
     return [x.payload.dottedQuad() for x in answer]
@@ -45,6 +46,7 @@ def lookupAs(hostname, *args, **kwargs):
 def lookupAAAAs(hostname, *args, **kwargs):
   def callback(result):
     answer, auth, add = result
+    answer = [x for x in answer if x.type == dns.AAAA]
     if len(answer) == 0:
       raise LookupException, "No ANSWERS in AAAA response for %s." % repr(hostname)
     return [expandIPv6(x.payload._address) for x in answer]


### PR DESCRIPTION
We might have clients with IPv6 addresses (e.g. proxied, with an IPv6 X-Forwarded-For: header); support reverse DNS lookups for those clients.

We might also encounter DNS answers that are not of the type requested, e.g. CNAME/DNAME records -- in which case the answer we care about is probably there too, and we just need to skip over anything unexpected.  (In particular, some networks are using CNAME/DNAME for reverse DNS.)