### PR TITLE
dns: actually support real IPv6 addresses

### DIFF
--- a/qwebirc/dns.py
+++ b/qwebirc/dns.py
@@ -19,10 +19,10 @@ def lookupPTR(ip, *args, **kwargs):
 def expandIPv6(ip):
   expand_sections = ["".join(["{:0>4}".format(group)
       for group in section.split(":")])
-        for section in ip.split("::")]
+        for section in ip.split("::", 1)]
   if len(expand_sections) == 1:
       return expand_sections[0]
-  return expand_sections[0] + (32-len(expand_start)-len(expand_end))*"0" + expand_sections[1:]
+  return expand_sections[0] + "".join((32-sum([len(x) for x in expand_sections]))*"0") + expand_sections[1]
 
 def lookupPTRv6(ip, *args, **kwargs):
   def callback(result):

--- a/qwebirc/root.py
+++ b/qwebirc/root.py
@@ -22,7 +22,7 @@ class ProxyRequest(server.Request):
     return True
     
   def getClientIP(self):
-    real_ip = http.Request.getClientIP(self)
+    real_ip = self.client.host
     if real_ip not in config.FORWARDED_FOR_IPS:
       return real_ip
       


### PR DESCRIPTION
Turns out my last PR didn't work if the IPv6 address contained ::, because I completely mangled the conversion back to a string.  Oops.

Also, fix getClientIP for IPv6 clients.