### PR TITLE
fixed support for IPv6 clients

### DIFF
--- a/qwebirc/dns.py
+++ b/qwebirc/dns.py
@@ -19,10 +19,10 @@ def lookupPTR(ip, *args, **kwargs):
 def expandIPv6(ip):
   expand_sections = ["".join(["{:0>4}".format(group)
       for group in section.split(":")])
-        for section in ip.split("::")]
+        for section in ip.split("::", 1)]
   if len(expand_sections) == 1:
       return expand_sections[0]
-  return expand_sections[0] + (32-len(expand_start)-len(expand_end))*"0" + expand_sections[1:]
+  return expand_sections[0] + "".join((32-sum([len(x) for x in expand_sections]))*"0") + expand_sections[1]
 
 def lookupPTRv6(ip, *args, **kwargs):
   def callback(result):


### PR DESCRIPTION
Turns out my PR #340 didn't work if the IPv6 address contained ::, because I completely mangled the conversion back to a string. Oops.

Also, fix getClientIP for IPv6 clients.  Twisted's implementation just returns None if the client is not IPv4.  This needs extra care to remove : at the beginning of addresses, e.g. IPv6-mapped IPv4 "::ffff:192.0.2.1", before we use those verbatim when talking to the IRC server.