### PR TITLE
Removal of cookie requirements for multiple backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ run.sh
 .idea
 *.iml
 .virtualenv
+venv

--- a/bin/optionsgen.py
+++ b/bin/optionsgen.py
@@ -10,6 +10,7 @@ def get_options():
     baseURL=config.BASE_URL,
     staticBaseURL=config.STATIC_BASE_URL,
     dynamicBaseURL=config.DYNAMIC_BASE_URL,
+    dynamicConfiguration=False,
     validateNickname=False,
     customMenuItems=[]
   )
@@ -33,5 +34,8 @@ def get_options():
 
   if hasattr(config, "ACCOUNT_WHOIS_COMMAND") and config.ACCOUNT_WHOIS_COMMAND:
     options["accountWhoisCommand"] = config.ACCOUNT_WHOIS_COMMAND
+
+  if hasattr(config, "DYNAMIC_CONFIGURATION") and config.DYNAMIC_CONFIGURATION:
+    options["dynamicConfiguration"] = True
 
   return json.dumps(options)

--- a/config.py.example
+++ b/config.py.example
@@ -258,6 +258,11 @@ STATIC_BASE_URL = ""
 #         instances on the same host.
 DYNAMIC_BASE_URL = ""
 
+# OPTION: DYNAMIC_CONFIGURATION
+#         If True then request configuration from the backend when we
+#         initially connect.
+DYNAMIC_CONFIGURATION = False
+
 # OPTION: CONNECTION_RESOLVER
 #         A list of (ip, port) tuples of resolvers to use for looking
 #         the SRV record(s) used for connecting to the name set in

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,8 +1,29 @@
-qwebirc.auth.loggedin = function() {
-  var user = Cookie.read("user");
-  var expiry = Cookie.read("loggedin");
-  if(user && expiry)
-    return user;
+qwebirc.auth.loggedin = function(uiUsage) {
+  if (typeof sessionStorage === "undefined") {
+    return;
+  }
+
+  var ticket = sessionStorage.getItem("qticket");
+  var user = sessionStorage.getItem("qticket_username");
+  var expiry = sessionStorage.getItem("qticket_expiry");
+
+  if (ticket === null) {
+    return;
+  }
+
+  if (uiUsage) {
+    if (Date.now() > expiry) {
+      sessionStorage.removeItem("qticket");
+      sessionStorage.removeItem("qticket_username");
+      sessionStorage.removeItem("qticket_expiry");
+      return;
+    }
+  } else {
+    /* if our ticket expired after we've shown it to the user: send it anyway */
+    /* we have a small grace period, and the server will tell the user if has really expired */
+  }
+
+  return [user, ticket];
 }
 
 qwebirc.auth.enabled = function() {

--- a/js/irc/baseircclient.js
+++ b/js/irc/baseircclient.js
@@ -36,8 +36,7 @@ qwebirc.irc.BaseIRCClient = new Class({
     this.connection = new qwebirc.irc.IRCConnection({
       initialNickname: this.nickname,
       onRecv: this.dispatch.bind(this),
-      serverPassword: this.options.serverPassword,
-      cloak: this.options.cloak
+      serverPassword: this.options.serverPassword
     });
   
     this.send = this.connection.send.bind(this.connection);

--- a/js/irc/ircclient.js
+++ b/js/irc/ircclient.js
@@ -242,7 +242,7 @@ qwebirc.irc.IRCClient = new Class({
       this.exec("/UMODE +x");
 
     if(this.options.autojoin) {
-      if(qwebirc.auth.loggedin() && this.ui.uiOptions.USE_HIDDENHOST) {
+      if(qwebirc.auth.loggedin(false) && this.ui.uiOptions.USE_HIDDENHOST) {
         var d = function() {
           if($defined(this.activeTimers.autojoin))
             this.ui.getActiveWindow().infoMessage("Waiting for login before joining channels...");

--- a/js/irc/ircconnection.js
+++ b/js/irc/ircconnection.js
@@ -423,8 +423,6 @@ qwebirc.irc.IRCConnection = new Class({
     var postdata = "nick=" + encodeURIComponent(this.initialNickname);
     if($defined(this.options.serverPassword))
       postdata+="&password=" + encodeURIComponent(this.options.serverPassword);
-    if($defined(this.options.cloak) && this.options.cloak)
-      postdata+="&cloak=true";
     r.send(postdata);
   },
   __decideTransport: function(transports) {

--- a/js/irc/ircconnection.js
+++ b/js/irc/ircconnection.js
@@ -396,8 +396,11 @@ qwebirc.irc.IRCConnection = new Class({
     r.send("s=" + this.sessionid + "&n=" + this.__subSeqNo);
   },
   connect: function() {
+    qwebirc.ui.requireDynamicConfiguration(this.__innerConnect.bind(this));
+  },
+  __innerConnect: function() {
     this.cacheAvoidance = qwebirc.util.randHexString(16);
-    
+
     var r = this.newRequest("n");
     r.addEvent("complete", function(o) {
       if(!o) {
@@ -416,7 +419,7 @@ qwebirc.irc.IRCConnection = new Class({
       this.__wsSupported = false;
       this.__decideTransport(transports);
     }.bind(this));
-    
+
     var postdata = "nick=" + encodeURIComponent(this.initialNickname);
     if($defined(this.options.serverPassword))
       postdata+="&password=" + encodeURIComponent(this.options.serverPassword);

--- a/js/irc/ircconnection.js
+++ b/js/irc/ircconnection.js
@@ -423,6 +423,9 @@ qwebirc.irc.IRCConnection = new Class({
     var postdata = "nick=" + encodeURIComponent(this.initialNickname);
     if($defined(this.options.serverPassword))
       postdata+="&password=" + encodeURIComponent(this.options.serverPassword);
+    var loggedin = qwebirc.auth.loggedin(false);
+    if(loggedin)
+      postdata+="&qticket=" + encodeURIComponent(loggedin[1]);
     r.send(postdata);
   },
   __decideTransport: function(transports) {

--- a/js/qwebircinterface.js
+++ b/js/qwebircinterface.js
@@ -31,7 +31,6 @@ qwebirc.ui.Interface = new Class({
     dynamicBaseURL: "/",
     staticBaseURL: "/",
     dynamicConfiguration: false,
-    cloak: false,
     logoURL: null,
     accountWhoisCommand: null
   },
@@ -72,7 +71,6 @@ qwebirc.ui.Interface = new Class({
 
     window.addEvent("domready", function() {
       var callback = function(options) {
-        options.cloak = ui_.options.cloak;
         var IRC = new qwebirc.irc.IRCClient(options, ui_);
         IRC.connect();
         window.onbeforeunload = qwebirc_ui_onbeforeunload;
@@ -134,9 +132,6 @@ qwebirc.ui.Interface = new Class({
           
         if(args.contains("randomnick") && args.get("randomnick") == 1)
           inick = this.options.initialNickname;
-
-        if(args.contains("cloak") && args.get("cloak") == 1)
-          this.options.cloak = true;
 
         /* we only consider autoconnecting if the nick hasn't been supplied, or it has and it's not "" */
         if(canAutoConnect && (!$defined(inick) || ($defined(inick) && (inick != "")))) {

--- a/js/qwebircinterface.js
+++ b/js/qwebircinterface.js
@@ -30,6 +30,7 @@ qwebirc.ui.Interface = new Class({
     nickValidation: null,
     dynamicBaseURL: "/",
     staticBaseURL: "/",
+    dynamicConfiguration: false,
     cloak: false,
     logoURL: null,
     accountWhoisCommand: null
@@ -62,9 +63,11 @@ qwebirc.ui.Interface = new Class({
     /* HACK */
     qwebirc.global = {
       dynamicBaseURL: options.dynamicBaseURL,
+      dynamicConfiguration: options.dynamicConfiguration,
       staticBaseURL: options.staticBaseURL,
       baseURL: options.baseURL,
-      nicknameValidator: $defined(options.nickValidation) ? new qwebirc.irc.NicknameValidator(options.nickValidation) : new qwebirc.irc.DummyNicknameValidator()
+      nicknameValidator: $defined(options.nickValidation) ? new qwebirc.irc.NicknameValidator(options.nickValidation) : new qwebirc.irc.DummyNicknameValidator(),
+      dynamicConfigurationLoaded: false
     };
 
     window.addEvent("domready", function() {
@@ -273,3 +276,17 @@ qwebirc.ui.Interface = new Class({
     return channel;
   }
 });
+
+qwebirc.ui.requireDynamicConfiguration = function(callback) {
+  if (!qwebirc.global.dynamicConfiguration || qwebirc.global.dynamicConfigurationLoaded) {
+    callback();
+    return;
+  }
+
+  var r = new Request.JSON({url: qwebirc.global.dynamicBaseURL + "configuration", onSuccess: function(data) {
+    qwebirc.global.dynamicBaseURL = data["dynamicBaseURL"];
+
+    callback();
+  }});
+  r.get();
+};

--- a/js/ui/baseui.js
+++ b/js/ui/baseui.js
@@ -533,15 +533,17 @@ qwebirc.ui.QuakeNetUI = new Class({
     return this.parent(name, window);
   },
   logout: function() {
-    if(!qwebirc.auth.loggedin())
+    if(!qwebirc.auth.loggedin(true)) {
+      this.getActiveWindow().errorMessage("Not logged in!");
       return;
+    }
     if(confirm("Log out?")) {
       this.clients.each(function(k, v) {
         v.quit("Logged out");
       }, this);
       
       /* HACK */
-      var foo = function() { document.location = qwebirc.global.dynamicBaseURL + "auth?logout=1"; };
+      var foo = function() { document.location = "/auth?logout=1"; };
       foo.delay(500);
     }
   }

--- a/js/ui/panes/connect.js
+++ b/js/ui/panes/connect.js
@@ -70,8 +70,9 @@ qwebirc.ui.ConnectPane = new Class({
         this.__validate = this.__validateLoginData;
       }
 
-      if(qwebirc.auth.loggedin()) {
-        exec("[name=authname]", util.setText(qwebirc.auth.loggedin()));
+      var login = qwebirc.auth.loggedin(true);
+      if(login) {
+        exec("[name=authname]", util.setText(login[0]));
         exec("[name=connectbutton]", util.makeVisible);
         exec("[name=loginstatus]", util.makeVisible);
       } else {
@@ -192,18 +193,27 @@ qwebirc.ui.ConnectPane = new Class({
       this.__cancelLoginCallback = null;
     }.bind(this);
 
-    this.util.exec("[name=loggingin]", this.util.setVisible(true));
-    this.util.exec("[name=" + calleename + "]", this.util.setVisible(false));
+    __qwebircAuthCallback = function(qticket, qticketUsername, realExpiry) {
+      if (typeof sessionStorage === "undefined")
+      {
+        alert("No session storage support in this browser -- login not supported");
+        this.__cancelLoginCallback(false);
+        return;
+      }
 
-    __qwebircAuthCallback = function(username, expiry, serverNow) {
       this.__cancelLoginCallback(true);
+      sessionStorage.setItem("qticket", qticket);
+      sessionStorage.setItem("qticket_username", qticketUsername);
+      sessionStorage.setItem("qticket_expiry", realExpiry);
 
       this.util.exec("[name=loggingin]", this.util.setVisible(false));
       this.util.exec("[name=loginstatus]", this.util.setVisible(true));
-      this.util.exec("[name=authname]", this.util.setText(username));
+      this.util.exec("[name=authname]", this.util.setText(qticketUsername));
       callback();
     }.bind(this);
 
+    this.util.exec("[name=loggingin]", this.util.setVisible(true));
+    this.util.exec("[name=" + calleename + "]", this.util.setVisible(false));
   },
   __validateConfirmData: function() {
     return {nickname: this.options.initialNickname, autojoin: this.options.initialChannels};


### PR DESCRIPTION
- Allows backend to send the URL to use rather than using cookies (no stick session required).
- Uses browser sessionStorage instead of SESSIONID cookie+server state for Q login tickets